### PR TITLE
fix: add function CamelSplitTokens to split tokens of camel-case varnames

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -18,6 +18,11 @@ func isLowerChar(ch byte) bool {
 }
 
 func CamelSplit(str string, sep string) string {
+	tokens := CamelSplitTokens(str)
+	return strings.Join(tokens, sep)
+}
+
+func CamelSplitTokens(str string) []string {
 	tokens := make([]string, 0)
 	var buf bytes.Buffer
 	upperCount := 0
@@ -53,7 +58,7 @@ func CamelSplit(str string, sep string) string {
 	if buf.Len() > 0 {
 		tokens = append(tokens, buf.String())
 	}
-	return strings.Join(tokens, sep)
+	return tokens
 }
 
 func Capitalize(str string) string {


### PR DESCRIPTION
增加CamelSplitTokens方法把CamelCase分割为tokens