### PR TITLE
fix: time reg not match negative time zone

### DIFF
--- a/util/regutils/regutils.go
+++ b/util/regutils/regutils.go
@@ -65,9 +65,9 @@ func init() {
 	MONTH_REG = regexp.MustCompile(`^\d{4}-\d{2}$`)
 	DATE_REG = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
 	DATE_COMPACT_REG = regexp.MustCompile(`^\d{8}$`)
-	ISO_TIME_REG = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|\+\d{2}:\d{2})$`)
-	ISO_NO_SECOND_TIME_REG = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(Z|\+\d{2}:\d{2})$`)
-	FULLISO_TIME_REG = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}(Z|\+\d{2}:\d{2})$`)
+	ISO_TIME_REG = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:\d{2})$`)
+	ISO_NO_SECOND_TIME_REG = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(Z|[+-]\d{2}:\d{2})$`)
+	FULLISO_TIME_REG = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}(Z|[+-]\d{2}:\d{2})$`)
 	COMPACT_TIME_REG = regexp.MustCompile(`^\d{14}$`)
 	ZSTACK_TIME_REG = regexp.MustCompile(`^\w+ \d{1,2}, \d{4} \d{1,2}:\d{1,2}:\d{1,2} (AM|PM)$`) //ZStack time format "Apr 1, 2019 3:23:17 PM"
 	MYSQL_TIME_REG = regexp.MustCompile(`^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$`)

--- a/util/regutils/regutils_test.go
+++ b/util/regutils/regutils_test.go
@@ -74,11 +74,15 @@ func TestRegexp(t *testing.T) {
 		{"0.168.192.in-addr.arpa", "MatchPtr", MatchPtr, false},
 		{"May 6, 2019 07:01:07 AM", "MatchZStackTime", MatchZStackTime, true},
 		{"2019-09-17T02:52:26.095915238+08:00", "MatchFullIsoNanotime", MatchFullISOTime, true},
+		{"2019-09-17T02:52:26.095915238-08:00", "MatchFullIsoNanotime", MatchFullISOTime, true},
 		{"2019-09-17T02:52:26.095915238Z", "MatchFullIsoNanotime", MatchFullISOTime, true},
 		{"2019-09-17T02:52:26.095915Z", "MatchFullIsoTime", MatchFullISOTime, true},
 		{"2019-09-17T02:52:26.09591Z", "MatchFullIsoTime2", MatchFullISOTime, true},
 		{"2019-09-17T02:52:26.095915+08:00", "MatchFullIsoTime", MatchFullISOTime, true},
+		{"2019-09-17T02:52:26.095915-08:00", "MatchFullIsoTime", MatchFullISOTime, true},
 		{"2019-09-17T02:52:26.095915+08:00", "MatchISOTime", MatchISOTime, false},
+		{"2019-09-17T02:52:26+08:00", "MatchISOTime", MatchISOTime, true},
+		{"2019-09-17T02:52:26-08:00", "MatchISOTime", MatchISOTime, true},
 	}
 	for _, c := range cases {
 		got := c.regfunc(c.in)


### PR DESCRIPTION
修正：时间正则不匹配负的时区，如2019-09-17T02:52:26-08:00