### PR TITLE
prometheus: use promhttp.Handler

### DIFF
--- a/util/prometheus/gin_handler.go
+++ b/util/prometheus/gin_handler.go
@@ -16,9 +16,9 @@ package prometheus
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 func InstallHandler(r *gin.Engine) {
-	r.Any("/metrics", gin.WrapH(prometheus.Handler()))
+	r.Any("/metrics", gin.WrapH(promhttp.Handler()))
 }


### PR DESCRIPTION
The old method was deprecated in upstream commit
761a2ff07c763475bff727730e823a8f4d501f36 ("Remove all deprecated
features").  It's a preparation for change commit v1.0.0

/cc @zexi @swordqiu 