### PR TITLE
refactor(reflectutils): Add StructFieldInfo Cache

### DIFF
--- a/util/reflectutils/jsonfield_test.go
+++ b/util/reflectutils/jsonfield_test.go
@@ -54,3 +54,30 @@ func TestParseStructFieldJsonInfo_Name(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkFetchStructFieldValueSet(b *testing.B) {
+	type GuestIp struct {
+		GuestIpStart string `width:"16" charset:"ascii" nullable:"false" list:"user" update:"user" create:"required"`
+		GuestIpEnd   string `width:"16" charset:"ascii" nullable:"false" list:"user" update:"user" create:"required"`
+		GuestIpMask  int8   `nullable:"false" list:"user" update:"user" create:"required"`
+	}
+	type Network struct {
+		GuestIp
+		VlanId int `nullable:"false" default:"1" list:"user" update:"user" create:"optional"`
+		WireId string `width:"36" charset:"ascii" nullable:"false" list:"user" create:"required"`
+	}
+	j := Network{
+		GuestIp: GuestIp{
+			GuestIpStart: "10.168.10.1",
+			GuestIpEnd: "10.168.10.244",
+			GuestIpMask: 24,
+		},
+		VlanId: 123,
+		WireId: "8324234723a",
+	}
+	v := reflect.ValueOf(j)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = FetchStructFieldValueSet(v)
+	}
+}


### PR DESCRIPTION
FetchStructFieldValueSet 是一个被频繁调用的函数，它将返回 Struct 的FieldInfo 和对应的 Value。实际上，其中的 FieldInfos是固定的，对同一类型的 Struct 调用 FetchStructFieldValueSet不应该重复计算 FieldInfos，所以这里引入了一个 Sync.Map 作为 Cache为每个 Struct Type 存储它的固定的 FieldInfos（这里是受 Go 标准库encoding/json 启发）。

基于同样的逻辑，SStructFieldInfo.MarshalName 中的 utils.CamelSplit也只应该调用一次，并在ParseFieldInfo的时候就可以直接计算出来。

基于此PR的 关于jsonutils Marshall 和 Unmarshall 的改进参考 [PR](https://github.com/yunionio/jsonutils/pull/17)。

#### 下面是基准测试的过程：
##### 测试代码
```go
func BenchmarkFetchStructFieldValueSet(b *testing.B) {
	type GuestIp struct {
		GuestIpStart string `width:"16" charset:"ascii" nullable:"false" list:"user" update:"user" create:"required"`
		GuestIpEnd   string `width:"16" charset:"ascii" nullable:"false" list:"user" update:"user" create:"required"`
		GuestIpMask  int8   `nullable:"false" list:"user" update:"user" create:"required"`
	}
	type Network struct {
		GuestIp
		VlanId int `nullable:"false" default:"1" list:"user" update:"user" create:"optional"`
		WireId string `width:"36" charset:"ascii" nullable:"false" list:"user" create:"required"`
	}
	j := Network{
		GuestIp: GuestIp{
			GuestIpStart: "10.168.10.1",
			GuestIpEnd: "10.168.10.244",
			GuestIpMask: 24,
		},
		VlanId: 123,
		WireId: "8324234723a",
	}
	v := reflect.ValueOf(j)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_ = FetchStructFieldValueSet(v)
	}
}
```
##### 测试1. 未修改前的版本
对应本PR的第一次 commit 。
```shell
go test -test.bench ^BenchmarkFetchStructFieldValueSet$ -test.run ^$ -benchmem
goos: darwin
goarch: amd64
pkg: yunion.io/x/pkg/util/reflectutils
BenchmarkFetchStructFieldValueSet-12              136498              8571 ns/op            7088 B/op        129 allocs/op
PASS
ok      yunion.io/x/pkg/util/reflectutils       3.001s
```
##### 测试2. 修改后，且有copy
对应本PR的第二次 commit。

使用 原生的 map 存储 fieldInfos ，每次 fetchStructFieldValueSet 最终都会对 fieldInfo 进行一次copy。
```shell
go test -test.bench ^BenchmarkFetchStructFieldValueSet$ -test.run ^$ -benchmem
goos: darwin
goarch: amd64
pkg: yunion.io/x/pkg/util/reflectutils
BenchmarkFetchStructFieldValueSet-12             1344092               886 ns/op            1328 B/op         11 allocs/op
PASS
ok      yunion.io/x/pkg/util/reflectutils       4.042s
```
##### 测试3. 修改后，且无copy
对应本PR的第三次 commit。

使用 wrapped map 存储 fieldInfos，每次 fetchStructFieldValueSet 最终不会copy。
```shell
go test -test.bench ^BenchmarkFetchStructFieldValueSet$ -test.run ^$ -benchmem
goos: darwin
goarch: amd64
pkg: yunion.io/x/pkg/util/reflectutils
BenchmarkFetchStructFieldValueSet-12             1751667               683 ns/op             560 B/op         11 allocs/op
PASS
ok      yunion.io/x/pkg/util/reflectutils       2.345s
```