### PR TITLE
.github: increase shallow fetch depth to 8

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
         with:
-          fetch-depth: 1
+          fetch-depth: 8
       - uses: actions/setup-go@v1.1.2
         with:
           go-version: '1.13'


### PR DESCRIPTION
To work around the following issue

	git checkout --progress --force 298a21f94a8c28bc8082a6135470b5f38d7b6f5c
	##[error]fatal: reference is not a tree: 298a21f94a8c28bc8082a6135470b5f38d7b6f5c
	##[warning]Git checkout failed on shallow repository, this might because of git fetch with depth '1' doesn't include the checkout commit '298a21f94a8c28bc8082a6135470b5f38d7b6f5c'.
	##[error]Git checkout failed with exit code: 128
	##[error]Exit code 1 returned from process: file name '/home/runner/runners/2.168.0/bin/Runner.PluginHost', arguments 'action "GitHub.Runner.Plugins.Repository.v1_0.CheckoutTask, Runner.Plugins"'.