### PR TITLE
fix: DiskDriver should be 'ide' when deploy windows vms on esxi.

### DIFF
--- a/util/osprofile/osprofile.go
+++ b/util/osprofile/osprofile.go
@@ -64,7 +64,7 @@ func GetOSProfile(osname string, hypervisor string) SOSProfile {
 	case OS_TYPE_WINDOWS:
 		if hypervisor == "esxi" {
 			return SOSProfile{
-				DiskDriver: "scsi",
+				DiskDriver: "ide",
 				NetDriver:  "e1000",
 				FsFormat:   "ntfs",
 			}


### PR DESCRIPTION
Refer by [PR](https://github.com/yunionio/onecloud/pull/6375).