### PR TITLE
feature: a map implementation with sorted key, specialized for jsonutils

### DIFF
--- a/sortedmap/iterator.go
+++ b/sortedmap/iterator.go
@@ -1,0 +1,43 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sortedmap
+
+type SSortedMapIterator struct {
+	smap  SSortedMap
+	index int
+}
+
+func (i *SSortedMapIterator) Init(smap SSortedMap) {
+	i.smap = smap
+	i.index = 0
+}
+
+func (i SSortedMapIterator) HasMore() bool {
+	return i.index < len(i.smap)
+}
+
+func (i *SSortedMapIterator) Next() {
+	i.index += 1
+}
+
+func (i SSortedMapIterator) Get() (string, interface{}) {
+	return i.smap[i.index].key, i.smap[i.index].value
+}
+
+func NewIterator(smap SSortedMap) *SSortedMapIterator {
+	iter := &SSortedMapIterator{}
+	iter.Init(smap)
+	return iter
+}

--- a/sortedmap/sortedmap.go
+++ b/sortedmap/sortedmap.go
@@ -1,0 +1,244 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sortedmap
+
+import (
+	"strings"
+)
+
+const (
+	INIT_CAPA = 10
+)
+
+type sItem struct {
+	key   string
+	value interface{}
+}
+
+type SSortedMap []sItem
+
+func NewSortedMap() SSortedMap {
+	return NewSortedMapWithCapa(INIT_CAPA)
+}
+
+func NewSortedMapWithCapa(capa int) SSortedMap {
+	return make([]sItem, 0, capa)
+}
+
+func NewSortedMapFromMap(omap map[string]interface{}) SSortedMap {
+	return NewSortedMapFromMapWithCapa(omap, 0)
+}
+
+func NewSortedMapFromMapWithCapa(omap map[string]interface{}, capa int) SSortedMap {
+	if capa < len(omap) {
+		capa = len(omap)
+	}
+	smap := NewSortedMapWithCapa(capa)
+	for k := range omap {
+		smap = Add(smap, k, omap[k])
+	}
+	return smap
+}
+
+func (ss SSortedMap) Keys() []string {
+	ret := make([]string, len(ss))
+	for i := range ss {
+		ret[i] = ss[i].key
+	}
+	return ret
+}
+
+func Add(ss SSortedMap, key string, value interface{}) SSortedMap {
+	if ss == nil {
+		ss = NewSortedMap()
+	}
+	pos, find := ss.find(key)
+	if find {
+		ss[pos].value = value
+		return ss
+	}
+	item := sItem{
+		key:   key,
+		value: value,
+	}
+	ss = append(ss, item)
+	copy(ss[pos+1:], ss[pos:])
+	ss[pos] = item
+	return ss
+}
+
+func Delete(ss SSortedMap, key string) (SSortedMap, bool) {
+	newsm, _, exist := deleteInternal(ss, key, false)
+	return newsm, exist
+}
+
+func deleteInternal(ss SSortedMap, key string, ignoreCase bool) (SSortedMap, string, bool) {
+	if ss == nil {
+		return ss, "", false
+	}
+	var pos int
+	var find bool
+	if ignoreCase {
+		pos, find = ss.findIgnoreCase(key)
+	} else {
+		pos, find = ss.find(key)
+	}
+	if !find {
+		return ss, "", false
+	}
+	caseKey := ss[pos].key
+	if pos < len(ss)-1 {
+		copy(ss[pos:], ss[pos+1:])
+	}
+	ss = ss[:len(ss)-1]
+	return ss, caseKey, true
+}
+
+func DeleteIgnoreCase(ss SSortedMap, key string) (SSortedMap, string, bool) {
+	return deleteInternal(ss, key, true)
+}
+
+func (ss SSortedMap) find(needle string) (int, bool) {
+	i := 0
+	j := len(ss) - 1
+	for i <= j {
+		m := (i + j) / 2
+		if ss[m].key < needle {
+			i = m + 1
+		} else if ss[m].key > needle {
+			j = m - 1
+		} else {
+			return m, true
+		}
+	}
+	return j + 1, false
+}
+
+func (ss SSortedMap) findIgnoreCase(needle string) (int, bool) {
+	pos, exist := ss.find(needle)
+	if exist {
+		return pos, true
+	}
+	for i := range ss {
+		if strings.EqualFold(ss[i].key, needle) {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+func (ss SSortedMap) Get(key string) (interface{}, bool) {
+	pos, find := ss.find(key)
+	if find {
+		return ss[pos].value, true
+	} else {
+		return nil, false
+	}
+}
+
+func (ss SSortedMap) GetIgnoreCase(key string) (interface{}, string, bool) {
+	pos, find := ss.findIgnoreCase(key)
+	if find {
+		return ss[pos].value, ss[pos].key, true
+	} else {
+		return nil, "", false
+	}
+}
+
+func (ss SSortedMap) Contains(needle string) bool {
+	_, find := ss.find(needle)
+	return find
+}
+
+func (ss SSortedMap) ContainsAny(needles ...string) bool {
+	for i := range needles {
+		_, find := ss.find(needles[i])
+		if find {
+			return true
+		}
+	}
+	return false
+}
+
+func (ss SSortedMap) ContainsAll(needles ...string) bool {
+	for i := range needles {
+		_, find := ss.find(needles[i])
+		if !find {
+			return false
+		}
+	}
+	return true
+}
+
+func Split(a, b SSortedMap) (a_b, anbA, anbB, b_a SSortedMap) {
+	minlen := len(a)
+	if minlen > len(b) {
+		minlen = len(b)
+	}
+	a_b = NewSortedMapWithCapa(len(a))
+	b_a = NewSortedMapWithCapa(len(b))
+	anbA = NewSortedMapWithCapa(minlen)
+	anbB = NewSortedMapWithCapa(minlen)
+	i := 0
+	j := 0
+	for i < len(a) && j < len(b) {
+		if a[i].key == b[j].key {
+			anbA = append(anbA, a[i])
+			anbB = append(anbB, b[j])
+			i += 1
+			j += 1
+		} else if a[i].key < b[j].key {
+			a_b = append(a_b, a[i])
+			i += 1
+		} else if a[i].key > b[j].key {
+			b_a = append(b_a, b[j])
+			j += 1
+		}
+	}
+	if i < len(a) {
+		a_b = append(a_b, a[i:]...)
+	}
+	if j < len(b) {
+		b_a = append(b_a, b[j:]...)
+	}
+	return
+}
+
+// order matters, values of the latter override the former
+func Merge(a, b SSortedMap) SSortedMap {
+	ret := NewSortedMapWithCapa(len(a) + len(b))
+	i := 0
+	j := 0
+	for i < len(a) && j < len(b) {
+		if a[i].key == b[j].key {
+			ret = append(ret, b[j])
+			i += 1
+			j += 1
+		} else if a[i].key < b[j].key {
+			ret = append(ret, a[i])
+			i += 1
+		} else if a[i].key > b[j].key {
+			ret = append(ret, b[j])
+			j += 1
+		}
+	}
+	if i < len(a) {
+		ret = append(ret, a[i:]...)
+	}
+	if j < len(b) {
+		ret = append(ret, b[j:]...)
+	}
+	return ret
+}

--- a/sortedmap/sortedmap_test.go
+++ b/sortedmap/sortedmap_test.go
@@ -1,0 +1,316 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sortedmap
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestSortedMap(t *testing.T) {
+	ss := NewSortedMapFromMap(map[string]interface{}{
+		"Go":     "Go",
+		"Bravo":  "Bravo",
+		"Gopher": "Gopher",
+		"Alpha":  "Alpha",
+		"Grin":   "Grin",
+		"Delta":  "Delta",
+	})
+	// Alpha Bravo Delta Go Gopher Grin
+	// 0     1     2     3  4      5
+	cases := []struct {
+		Needle string
+		Index  int
+		Want   bool
+	}{
+		{"Go", 3, true},
+		{"Bravo", 1, true},
+		{"Gopher", 4, true},
+		{"Alpha", 0, true},
+		{"Grin", 5, true},
+		{"Delta", 2, true},
+		{"Go1", 4, false},
+		{"G", 3, false},
+		{"A", 0, false},
+		{"T", 6, false},
+	}
+	for _, c := range cases {
+		idx, find := ss.find(c.Needle)
+		if idx != c.Index || find != c.Want {
+			t.Errorf("%s: want: %d %v got: %d %v", c.Needle, c.Index, c.Want, idx, find)
+		}
+	}
+}
+
+func TestSplitMaps(t *testing.T) {
+	cases := []struct {
+		input  map[string]interface{}
+		input2 map[string]interface{}
+		want1  []string
+		want2  []string
+		want3  []string
+	}{
+		{
+			input:  map[string]interface{}{"Go": 1, "Bravo": 1, "Gopher": 1, "Alpha": 1, "Grin": 1, "Delta": 1},
+			input2: map[string]interface{}{"Go2": 2, "Bravo": 2, "Gopher": 2, "Alpha1": 2, "Grin": 2, "Delt": 2},
+			want1:  []string{"Alpha", "Delta", "Go"},
+			want2:  []string{"Bravo", "Gopher", "Grin"},
+			want3:  []string{"Alpha1", "Delt", "Go2"},
+		},
+	}
+
+	for _, c := range cases {
+		ss1 := NewSortedMapFromMap(c.input)
+		ss2 := NewSortedMapFromMap(c.input2)
+
+		a, b1, b2, d := Split(ss1, ss2)
+		if !reflect.DeepEqual(a.Keys(), c.want1) {
+			t.Fatalf("A-B got %s want %s", a.Keys(), c.want1)
+		}
+		if !reflect.DeepEqual(b1.Keys(), c.want2) {
+			t.Fatalf("A and B in A got %s want %s", b1.Keys(), c.want2)
+		}
+		if !reflect.DeepEqual(b2.Keys(), c.want2) {
+			t.Fatalf("A and B in B got %s want %s", b2.Keys(), c.want2)
+		}
+		if !reflect.DeepEqual(d.Keys(), c.want3) {
+			t.Fatalf("B-A got %s want %s", d.Keys(), c.want3)
+		}
+	}
+}
+
+func TestMergeMaps(t *testing.T) {
+	cases := []struct {
+		input  map[string]interface{}
+		input2 map[string]interface{}
+		want   []string
+	}{
+		{
+			input:  map[string]interface{}{"Go": 1, "Bravo": 1, "Gopher": 1, "Alpha": 1, "Grin": 1, "Delta": 1},
+			input2: map[string]interface{}{"Go2": 2, "Bravo": 2, "Gopher": 2, "Alpha1": 2, "Grin": 2, "Delt": 2},
+			want:   []string{"Alpha", "Alpha1", "Bravo", "Delt", "Delta", "Go", "Go2", "Gopher", "Grin"},
+		},
+	}
+	for _, c := range cases {
+		ss1 := NewSortedMapFromMap(c.input)
+		ss2 := NewSortedMapFromMap(c.input2)
+
+		m := Merge(ss1, ss2)
+		if !reflect.DeepEqual(m.Keys(), c.want) {
+			t.Fatalf("merge got %s want %s", m.Keys(), c.want)
+		}
+	}
+}
+
+func TestSortedStringsAppend(t *testing.T) {
+	cases := []struct {
+		in   []string
+		ele  []string
+		want []string
+	}{
+		{
+			in:   []string{"Alpha", "Bravo", "Go"},
+			ele:  []string{"Go2"},
+			want: []string{"Alpha", "Bravo", "Go", "Go2"},
+		},
+		{
+			in:   []string{"Alpha", "Bravo", "Go2"},
+			ele:  []string{"Go"},
+			want: []string{"Alpha", "Bravo", "Go", "Go2"},
+		},
+		{
+			in:   []string{"Alpha", "Bravo", "Go2"},
+			ele:  []string{"Aaaa", "Go"},
+			want: []string{"Aaaa", "Alpha", "Bravo", "Go", "Go2"},
+		},
+	}
+	for _, c := range cases {
+		ss := NewSortedMap()
+		for _, v := range c.in {
+			ss = Add(ss, v, 1)
+		}
+		for _, v := range c.ele {
+			ss = Add(ss, v, 1)
+		}
+		got := ss.Keys()
+		if !reflect.DeepEqual(c.want, got) {
+			t.Errorf("want: %s got: %s", c.want, got)
+		}
+	}
+}
+
+func TestSortedStringsRemove(t *testing.T) {
+	cases := []struct {
+		in   []string
+		ele  []string
+		want []string
+	}{
+		{
+			in:   []string{"Alpha", "Bravo", "Go"},
+			ele:  []string{"Go", "Go2"},
+			want: []string{"Alpha", "Bravo"},
+		},
+		{
+			in:   []string{"Alpha", "Bravo", "Go2"},
+			ele:  []string{"Go"},
+			want: []string{"Alpha", "Bravo", "Go2"},
+		},
+		{
+			in:   []string{"Alpha", "Bravo", "Go", "Go2"},
+			ele:  []string{"Aaaa", "Alpha"},
+			want: []string{"Bravo", "Go", "Go2"},
+		},
+	}
+	for _, c := range cases {
+		ss := NewSortedMap()
+		for _, v := range c.in {
+			ss = Add(ss, v, 1)
+		}
+		for _, v := range c.ele {
+			ss, _ = Delete(ss, v)
+		}
+		got := ss.Keys()
+		if !reflect.DeepEqual(c.want, got) {
+			t.Errorf("want: %s got: %s", c.want, got)
+		}
+	}
+}
+
+func TestSortedStringsDeleteIgnoreCase(t *testing.T) {
+	cases := []struct {
+		in   []string
+		ele  []string
+		want []string
+	}{
+		{
+			in:   []string{"Alpha", "Bravo", "Go"},
+			ele:  []string{"go", "Go2"},
+			want: []string{"Alpha", "Bravo"},
+		},
+		{
+			in:   []string{"Alpha", "Bravo", "Go2"},
+			ele:  []string{"Go"},
+			want: []string{"Alpha", "Bravo", "Go2"},
+		},
+		{
+			in:   []string{"Alpha", "Bravo", "Go", "Go2"},
+			ele:  []string{"Aaaa", "alpha"},
+			want: []string{"Bravo", "Go", "Go2"},
+		},
+	}
+	for _, c := range cases {
+		ss := NewSortedMap()
+		for _, v := range c.in {
+			ss = Add(ss, v, 1)
+		}
+		for _, v := range c.ele {
+			ss, _, _ = DeleteIgnoreCase(ss, v)
+		}
+		got := ss.Keys()
+		if !reflect.DeepEqual(c.want, got) {
+			t.Errorf("want: %s got: %s", c.want, got)
+		}
+	}
+}
+
+func TestCopy(t *testing.T) {
+	const (
+		alphabet  = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+		alphabet1 = "AABCDEFGHIJKLMNOPQRSTUVWXY"
+		alphabet2 = "BCDEFGHIJKLMNOPQRSTUVWXYZZ"
+	)
+	s := []byte(alphabet)
+	copy(s[1:], s)
+	if string(s) != alphabet1 {
+		t.Fatalf("right shift fail")
+	}
+	w := []byte(alphabet)
+	copy(w, w[1:])
+	if string(w) != alphabet2 {
+		t.Fatalf("left shift fail")
+	}
+}
+
+func TestIterator(t *testing.T) {
+	input := map[string]interface{}{"Go": 1, "Bravo": 1, "Gopher": 1, "Alpha": 1, "Grin": 1, "Delta": 1}
+	ss := NewSortedMapFromMap(input)
+	keys := make([]string, 0)
+	for iter := NewIterator(ss); iter.HasMore(); iter.Next() {
+		k, _ := iter.Get()
+		keys = append(keys, k)
+	}
+	if !reflect.DeepEqual(keys, ss.Keys()) {
+		t.Fatalf("keys not equal %s != %s", keys, ss.Keys())
+	}
+}
+
+func BenchmarkAdd(b *testing.B) {
+	for _, size := range []int{10, 100, 1000, 10000} {
+		input := make(map[string]interface{})
+		keys := []string{
+			"Go", "Bravo", "Gopher", "Alpha", "Grin", "Delta", "Delta2", "Alpha3",
+		}
+		for i := 0; i < size; i++ {
+			input[fmt.Sprintf("%s-%d", keys[i%len(keys)], i)] = 1
+		}
+		ss := NewSortedMapFromMap(input)
+		b.Run(fmt.Sprintf("sortedMap-%d", size), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ss = Add(ss, "Go2", 1)
+				ss = Add(ss, "Aloha2", 1)
+				ss = Add(ss, "Zero2", 1)
+			}
+		})
+		b.Run(fmt.Sprintf("rawMap-%d", size), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				input["Go2"] = 1
+				input["Aloha2"] = 1
+				input["Zero2"] = 1
+			}
+		})
+	}
+}
+
+func BenchmarkDelete(b *testing.B) {
+	for _, size := range []int{10, 100, 1000, 10000} {
+		keys := []string{
+			"Go", "Bravo", "Bravo2", "Gopher", "Alpha", "Grin", "Delta", "Delt", "Delta2", "Alpha3", "Zoom",
+		}
+		input := make(map[string]interface{})
+		for i := 0; i < size; i++ {
+			input[fmt.Sprintf("%s-%d", keys[i%len(keys)], i)] = 1
+		}
+		ss := NewSortedMapFromMap(input)
+		b.Run(fmt.Sprintf("sortedMap-%d", size), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ss, _ = Delete(ss, "Grin")
+				ss, _ = Delete(ss, "Bravo")
+				ss, _ = Delete(ss, "Zoom")
+			}
+		})
+		b.Run(fmt.Sprintf("rawMap-%d", size), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				delete(input, "Grin")
+				delete(input, "Bravo")
+				delete(input, "Zoom")
+			}
+		})
+	}
+}


### PR DESCRIPTION
增加：key为排序的字符串的sortedmap实现，用于jsonutils存储jsonDict数据

性能对比：
$ GO111MODULE=off go test -bench . -benchtime 20s
goos: linux
goarch: amd64
pkg: yunion.io/x/pkg/sortedmap
BenchmarkAdd/sortedMap-10-8             285528043               93.1 ns/op
BenchmarkAdd/rawMap-10-8                533855942               51.5 ns/op
BenchmarkAdd/sortedMap-100-8            100000000              213 ns/op
BenchmarkAdd/rawMap-100-8               430674688               54.9 ns/op
BenchmarkAdd/sortedMap-1000-8           84351110               264 ns/op
BenchmarkAdd/rawMap-1000-8              617273582               38.9 ns/op
BenchmarkAdd/sortedMap-10000-8          64553646               364 ns/op
BenchmarkAdd/rawMap-10000-8             450599668               52.3 ns/op
BenchmarkDelete/sortedMap-10-8          218977027              104 ns/op
BenchmarkDelete/rawMap-10-8             532830482               46.9 ns/op
BenchmarkDelete/sortedMap-100-8         100000000              202 ns/op
BenchmarkDelete/rawMap-100-8            410201071               60.0 ns/op
BenchmarkDelete/sortedMap-1000-8        79332259               338 ns/op
BenchmarkDelete/rawMap-1000-8           443364318               59.1 ns/op
BenchmarkDelete/sortedMap-10000-8       51289579               477 ns/op
BenchmarkDelete/rawMap-10000-8          446378776               51.5 ns/op
PASS
ok      yunion.io/x/pkg/sortedmap       447.927s

sortemap插入和删除时间大概为golang native map的一倍左右，但可以直接输出key为排好的值

/cc @zexi @yousong 