### PR TITLE
fix: set default private prefixes if no parameter given

### DIFF
--- a/util/netutils/netutils.go
+++ b/util/netutils/netutils.go
@@ -422,13 +422,7 @@ var linkLocalIPRange IPV4AddrRange
 var multicastIPRange IPV4AddrRange
 
 func init() {
-	privatePrefixes := []string{
-		"10.0.0.0/8",
-		"172.16.0.0/12",
-		"192.168.0.0/16",
-	}
-
-	updatePrivateIPRanges(privatePrefixes)
+	updatePrivateIPRanges(nil)
 
 	prefix, _ := NewIPV4Prefix(hostlocalPrefix)
 	hostLocalIPRange = prefix.ToIPRange()
@@ -451,7 +445,11 @@ func updatePrivateIPRanges(prefs []string) {
 
 func SetPrivatePrefixes(pref []string) {
 	if len(pref) == 0 {
-		return
+		pref = []string{
+			"10.0.0.0/8",
+			"172.16.0.0/12",
+			"192.168.0.0/16",
+		}
 	}
 	updatePrivateIPRanges(pref)
 }


### PR DESCRIPTION
修正：设置空的私有云列表时，恢复为默认的私有云列表