### PR TITLE
delayedwork: initial version

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -15,9 +15,9 @@ jobs:
       - uses: actions/checkout@v1
         with:
           fetch-depth: 8
-      - uses: actions/setup-go@v1.1.2
+      - uses: actions/setup-go@v2
         with:
-          go-version: '1.13'
+          go-version: '1.14'
       - name: test
         shell: bash
         run: |

--- a/util/delayedwork/delayedwork.go
+++ b/util/delayedwork/delayedwork.go
@@ -1,0 +1,139 @@
+package delayedwork
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+var (
+	maxDuration = time.Duration(290 * 365 * 24 * time.Hour)
+	maxTime     = time.Now().Add(maxDuration)
+)
+
+type DelayedWorkFunc func(context.Context)
+type delayedWork struct {
+	id       string
+	created  time.Time
+	interval time.Duration
+	deadline time.Time
+	f        DelayedWorkFunc
+
+	last    time.Time
+	dueTime time.Time
+}
+
+func (dw *delayedWork) initDueTime() {
+	t0 := dw.last.Add(dw.interval)
+	if t0.Before(dw.deadline) {
+		dw.dueTime = t0
+		return
+	}
+	dw.dueTime = dw.deadline
+}
+
+type DelayedWorkManager struct {
+	works   map[string]*delayedWork
+	worksMu *sync.Mutex
+	sigch   chan struct{}
+}
+
+func NewDelayedWorkManager() *DelayedWorkManager {
+	dwm := &DelayedWorkManager{
+		works:   map[string]*delayedWork{},
+		worksMu: &sync.Mutex{},
+		sigch:   make(chan struct{}),
+	}
+	return dwm
+}
+
+func (dwm *DelayedWorkManager) pendingCount() int {
+	dwm.worksMu.Lock()
+	defer dwm.worksMu.Unlock()
+	return len(dwm.works)
+}
+
+func (dwm *DelayedWorkManager) Start(ctx context.Context) {
+	var (
+		tmr *time.Timer
+		dw  *delayedWork
+	)
+	for {
+		tmr, dw = dwm.calRecentWork(ctx)
+		select {
+		case <-tmr.C:
+			if dw != nil {
+				dwm.worksMu.Lock()
+				delete(dwm.works, dw.id)
+				dwm.worksMu.Unlock()
+
+				go dw.f(ctx)
+			}
+		case <-dwm.sigch:
+			if !tmr.Stop() {
+				<-tmr.C
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (dwm *DelayedWorkManager) calRecentWork(ctx context.Context) (*time.Timer, *delayedWork) {
+	dwm.worksMu.Lock()
+	defer dwm.worksMu.Unlock()
+
+	var (
+		rt  = maxTime
+		rdw *delayedWork
+	)
+	// use container/heap should it be huge
+	for _, dw := range dwm.works {
+		if rt.After(dw.dueTime) {
+			rt = dw.dueTime
+			rdw = dw
+		}
+	}
+	return time.NewTimer(rt.Sub(time.Now())), rdw
+}
+
+// DelayedWorkRequest serves as an argument to DelayedWorkManager.Submit
+//
+// ID should be unique among works managed here
+//
+// Every submit of the same work as identified by ID will be delayed for at
+// most SoftDelay time
+//
+// Func will be called after either SoftDelay since each submit, or HardDelay
+// since first submit, whichever comes first
+type DelayedWorkRequest struct {
+	ID        string
+	SoftDelay time.Duration
+	HardDelay time.Duration
+	Func      DelayedWorkFunc
+}
+
+func (dwm *DelayedWorkManager) Submit(ctx context.Context, req DelayedWorkRequest) {
+	dwm.worksMu.Lock()
+	dw, ok := dwm.works[req.ID]
+	if !ok {
+		now := time.Now()
+		dw = &delayedWork{
+			id:       req.ID,
+			created:  now,
+			interval: req.SoftDelay,
+			deadline: now.Add(req.HardDelay),
+			f:        req.Func,
+
+			last: now,
+		}
+		dwm.works[req.ID] = dw
+		dw.initDueTime()
+	} else {
+		dw.last = time.Now()
+		dw.initDueTime()
+	}
+	dwm.worksMu.Unlock()
+
+	dwm.sigch <- struct{}{}
+}

--- a/util/delayedwork/delayedwork_test.go
+++ b/util/delayedwork/delayedwork_test.go
@@ -1,0 +1,103 @@
+package delayedwork
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type delayedWorkTester struct {
+	count int32
+}
+
+func (dwt *delayedWorkTester) do(t *testing.T) {
+	atomic.AddInt32(&dwt.count, 1)
+}
+
+func drainDwm(ctx context.Context, dwm *DelayedWorkManager) {
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		select {
+		case <-tick.C:
+			count := dwm.pendingCount()
+			if count == 0 {
+				return
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func TestDelayedWork(t *testing.T) {
+	t.Run("one-soft", func(t *testing.T) {
+		ctx := context.Background()
+		ctx, cancelFunc := context.WithTimeout(ctx, 10*time.Second)
+		defer cancelFunc()
+
+		dwm := NewDelayedWorkManager()
+		go dwm.Start(ctx)
+
+		var (
+			startTime = time.Now()
+			dwt       delayedWorkTester
+			req       = DelayedWorkRequest{
+				ID:        "1",
+				SoftDelay: time.Second,
+				HardDelay: 3 * time.Second,
+				Func: func(ctx context.Context) {
+					dwt.do(t)
+				},
+			}
+		)
+		dwm.Submit(ctx, req)
+		time.Sleep(500 * time.Millisecond)
+		dwm.Submit(ctx, req)
+		drainDwm(ctx, dwm)
+		if dwt.count != 1 {
+			t.Errorf("got %d, want 1", dwt.count)
+		}
+		if elp := time.Since(startTime); elp <= 1500*time.Millisecond {
+			t.Errorf("elapse time too short: %s", elp)
+		} else if elp >= 1550*time.Millisecond {
+			t.Errorf("elapse time too long: %s", elp)
+		}
+	})
+	t.Run("one-hard", func(t *testing.T) {
+		ctx := context.Background()
+		ctx, cancelFunc := context.WithTimeout(ctx, 10*time.Second)
+		defer cancelFunc()
+
+		dwm := NewDelayedWorkManager()
+		go dwm.Start(ctx)
+
+		var (
+			startTime = time.Now()
+			dwt       delayedWorkTester
+			req       = DelayedWorkRequest{
+				ID:        "1",
+				SoftDelay: time.Second,
+				HardDelay: 3 * time.Second,
+				Func: func(ctx context.Context) {
+					dwt.do(t)
+				},
+			}
+		)
+		dwm.Submit(ctx, req)
+		for i := 0; i < 17; i++ {
+			time.Sleep(200 * time.Millisecond)
+			dwm.Submit(ctx, req)
+		}
+		drainDwm(ctx, dwm)
+		if dwt.count != 2 {
+			t.Errorf("got %d, want 2", dwt.count)
+		}
+		if elp := time.Since(startTime); elp <= 4400*time.Millisecond {
+			t.Errorf("elapse time too short: %s", elp)
+		} else if elp >= 4450*time.Millisecond {
+			t.Errorf("elapse time too long: %s", elp)
+		}
+	})
+}


### PR DESCRIPTION
对于幂等、耗时的动作，将短时发生的多个执行请求压缩成一次最末请求。比如批量变更虚机下属资源时的sync task

/cc @ioito @zexi @swordqiu @wanyaoqi 